### PR TITLE
ECIP-1056 (Agharta): revise draft w/r/t EIP-1702 EVM Account Versioning

### DIFF
--- a/ECIPs/ecip-1056.md
+++ b/ECIPs/ecip-1056.md
@@ -88,7 +88,7 @@ The following clients with Ethereum Classic support __implement the _Constaninop
 The following clients with Ethereum Classic support __implement the EIP1702-derived Generalized Account Versioning Scheme__:
 
 - Geth Classic: no support
-- Parity Ethereum: no support (?)
+- Parity Ethereum: full support as per [paritytech/parity-ethereum#10771](https://github.com/paritytech/parity-ethereum/pull/10771)
 - Multi Geth: no support
 
 

--- a/ECIPs/ecip-1056.md
+++ b/ECIPs/ecip-1056.md
@@ -31,9 +31,10 @@ Further, add support for:
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `1_500_000` on Kotti Classic PoA-testnet (early November 2019)
-- `5_200_000` on Morden Classic PoW-testnet (early November 2019)
-- `9_200_000` on Ethereum Classic PoW-mainnet (early December 2019)
+- Morden Testnet (_deprecated_), Dec 11, 2019, 12pm UTC, block `5_348_435` (Gethc, Parity)
+- Mordor Testnet, Jan 15, 2020, 12pm UTC, block `617_716` (Gethc, Parity, Mgeth)
+- Kotti Testnet, Feb 05, 2020, 12pm UTC, block `2_028_202` (Parity, Mgeth)
+- Classic Mainnet, Apr 15, 2020, 12pm UTC, _no block number required yet_
 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.

--- a/ECIPs/ecip-1056.md
+++ b/ECIPs/ecip-1056.md
@@ -46,7 +46,7 @@ section of this document.
 
 ### Specification
 
-Enable the following four hard fork features: 
+Enable the following four hard fork features:
 
 - [EIP-1702](https://eips.ethereum.org/EIPS/eip-1702) Generalized Account Versioning; see "Specification" section (commonly known as EIP-1702 variant I)
   + Determine a new account version `0x1`, as specified in link above, and detailed in paragraph below.

--- a/ECIPs/ecip-1056.md
+++ b/ECIPs/ecip-1056.md
@@ -81,7 +81,7 @@ Adoption of the content of this ECIP requires a hard fork as it introduces chang
 
 The following clients with Ethereum Classic support __implement the _Constaninople_ and _Petersburg_ opcodes__ currently:
 
-- Geth Classic: no support
+ - Geth Classic: all features as per [etclabscore/go-ethereum#40](https://github.com/etclabscore/go-ethereum/issues/40)
 - Parity Ethereum: all features due to Ethereum Foundation compatibility
 - Multi Geth: all features due to Ethereum Foundation compatibility
 

--- a/ECIPs/ecip-1056.md
+++ b/ECIPs/ecip-1056.md
@@ -84,14 +84,12 @@ The following clients with Ethereum Classic support __implement the _Constaninop
 - Geth Classic: no support
 - Parity Ethereum: all features due to Ethereum Foundation compatibility
 - Multi Geth: all features due to Ethereum Foundation compatibility
-- Mantis: all features due to Ethereum Foundation compatibility
 
 The following clients with Ethereum Classic support __implement the EIP1702-derived Generalized Account Versioning Scheme__:
 
 - Geth Classic: no support
 - Parity Ethereum: no support (?)
 - Multi Geth: no support
-- Mantis: no support (?)
 
 
 ## Copyright

--- a/ECIPs/ecip-1056.md
+++ b/ECIPs/ecip-1056.md
@@ -10,17 +10,24 @@ created: 2019-03-25
 
 ### Simple Summary
 
-Enable the outstanding Ethereum Foundation _Constaninople_ and _Petersburg_ network protocol upgrades on the Ethereum
-Classic network in a hard-fork code-named _Agharta_ to enable maximum compatibility across these networks.
+Enable the outstanding Ethereum Foundation _Constaninople_ and _Petersburg_ EVM opcode upgrades, while also introducing a _Generalized Account Versioning Scheme_ for the EVM. 
+
+These changes would be made on the Ethereum Classic network in a hard-fork code-named _Agharta_ to enable maximum compatibility across EVM-based networks and to ensure backwards-compatiblity for existing contracts across hardforks modifying VM rules.
 
 ### Abstract
 
 Add support for a subset of protocol-impacting changes introduced in the Ethereum Foundation (ETH) network via the
-_Constaninople_ and _Petersburg_ hardforks. The proposed changes for Ethereum Classic's _Agharta_ upgrade include:
+_Constaninople_ and _Petersburg_ hardforks. The proposed changes for Ethereum Classic's _Agharta_ upgrade include the following opcode introductions:
 
 - Constantinople bitwise shifting instructions
 - Constantinople skinny `CREATE2` opcode
 - Constantinople `EXTCODEHASH` opcode
+
+Further, add support for:
+ - Generalized Account Versioning [EIP-1702: Generalized Account Versioning Scheme](https://eips.ethereum.org/EIPS/eip-1702), which "defines a method of hard forking while maintaining the exact functionality of existing account by allowing multiple versions of the virtual machines to execute in the same block."
+ 
+ 
+#### Schedule
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
@@ -31,20 +38,23 @@ This document proposes the following blocks at which to implement these changes 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.
 
-### Motivation
+### Motivations
 
-To enhance the Ethereum Virtual Machine's (EVM) capabilities, various opcodes shall be added to the Ethereum Classic
-networks, all of which have been in use on the Ethereum Foundation networks since early 2019.
+- To enhance the Ethereum Virtual Machine's (EVM) capabilities in order to maintain congruence with ETH, which has implemented these opcodes since early 2019. (EIP-145, EIP-1014, EIP-1052)
+- To allow "breaking features to be implemented while making sure existing contracts work as expected." (EIP-1702)
 
 ### Specification
 
-Enable the following three hard fork features via a new account version `0x1`, as specified in [EIP-1702](https://eips.ethereum.org/EIPS/eip-1702) "Specification" section (commonly known as EIP-1702 variant I):
+Enable the following four hard fork features: 
 
+- [EIP-1702](https://eips.ethereum.org/EIPS/eip-1702) Generalized Account Versioning; see "Specification" section (commonly known as EIP-1702 variant I)
+  + Determine a new account version `0x1`, as specified in link above, and detailed in paragraph below.
 - [EIP 145](https://eips.ethereum.org/EIPS/eip-145) (Bitwise shifting instructions)
 - [EIP 1014](https://eips.ethereum.org/EIPS/eip-1014) (Skinny `CREATE2` opcode)
 - [EIP 1052](https://eips.ethereum.org/EIPS/eip-1052) (`EXTCODEHASH` opcode)
 
-Specifically with definition from EIP-1702 "Usage Template" section:
+
+Specifically with definition from __EIP-1702 "Usage Template"__ section:
 
 - **Version**: `0x1`.
 - **Parent version**: `0x0`.
@@ -68,12 +78,20 @@ increases its functionality and should be considered a feature upgrade rather th
 
 Adoption of the content of this ECIP requires a hard fork as it introduces changes that are not backward compatible.
 
-The following clients with Ethereum Classic support implement the _Constaninople_ and _Petersburg_ features currently:
+The following clients with Ethereum Classic support __implement the _Constaninople_ and _Petersburg_ opcodes__ currently:
 
 - Geth Classic: no support
 - Parity Ethereum: all features due to Ethereum Foundation compatibility
 - Multi Geth: all features due to Ethereum Foundation compatibility
 - Mantis: all features due to Ethereum Foundation compatibility
+
+The following clients with Ethereum Classic support __implement the EIP1702-derived Generalized Account Versioning Scheme__:
+
+- Geth Classic: no support
+- Parity Ethereum: no support (?)
+- Multi Geth: no support
+- Mantis: no support (?)
+
 
 ## Copyright
 


### PR DESCRIPTION
The previous iteration of this document downplayed the introduction
of making the EVM use versioned contract accounts.

This is a complex and significant change and demands adequate attention in the
document and discussion.

This change (including EIP1702 in this fork's "Meta-ECIP") was originally made here: https://github.com/ethereumclassic/ECIPs/commit/4d227a254e69cd1def7765c0d5da91a6606050f1